### PR TITLE
add src/ to package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "main": "src/index.js",
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "directories": {
     "src": "src",


### PR DESCRIPTION
otherwise you can't `require()` it from browserify
